### PR TITLE
Add ELK IMAP ingestion stack

### DIFF
--- a/imap_elk_ingest/README.md
+++ b/imap_elk_ingest/README.md
@@ -1,0 +1,27 @@
+# ELK-Mail IMAP Ingestion
+
+This directory contains a simple proof of concept for ingesting alert mails via IMAP into an Elastic stack running on a single host using Docker Compose.
+
+## Directory Layout
+
+- `docker-compose.yml` – Docker Compose file bringing up Elasticsearch, Kibana and a custom Logstash image.
+- `extensions/logstash/Dockerfile` – builds Logstash with the `logstash-input-imap` plugin.
+- `logstash/pipeline/mail_imap.conf` – Logstash pipeline definition for pulling mails from IMAPS and indexing them into Elasticsearch.
+
+## Usage
+
+1. Build the custom Logstash image:
+   ```bash
+   docker compose build
+   ```
+2. Start the stack:
+   ```bash
+   docker compose up -d
+   ```
+3. Create the ILM policy and index template:
+   ```bash
+   bash setup_ilm.sh
+   ```
+4. Access Kibana at `http://localhost:5601` and add the index pattern `imap-mail-*`.
+
+A basic setup script `setup_ilm.sh` is provided to configure the rollover and retention policy described in the specification.

--- a/imap_elk_ingest/docker-compose.yml
+++ b/imap_elk_ingest/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms8g -Xmx8g
+      - xpack.security.enabled=false
+    volumes:
+      - /data_ssd_nvme2/es:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.12.2
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+
+  logstash:
+    build: ./extensions/logstash
+    environment:
+      - LS_JAVA_OPTS=-Xms2g -Xmx2g
+    volumes:
+      - ./logstash/pipeline:/usr/share/logstash/pipeline
+    depends_on:
+      - elasticsearch

--- a/imap_elk_ingest/extensions/logstash/Dockerfile
+++ b/imap_elk_ingest/extensions/logstash/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/logstash/logstash:8.12.2
+RUN bin/logstash-plugin install --no-verify logstash-input-imap

--- a/imap_elk_ingest/logstash/pipeline/mail_imap.conf
+++ b/imap_elk_ingest/logstash/pipeline/mail_imap.conf
@@ -1,0 +1,36 @@
+input {
+  imap {
+    host => "imap.example.com"
+    user => "alert@example.com"
+    password => "********"
+    secure => true
+    folder => "INBOX"
+    fetch_count => 10
+    check_interval => 300
+    type => "imap_alert"
+  }
+}
+
+filter {
+  grok {
+    match => {
+      "message" => "(?m)^Date: %{GREEDYDATA:mail_date}\nFrom: %{GREEDYDATA:mail_from}\nTo: %{GREEDYDATA:mail_to}\nSubject: %{GREEDYDATA:mail_subject}"
+    }
+  }
+  mutate {
+    rename => { "message" => "mail_body_raw" }
+    add_field => { "ingest_type" => "imap_direct" }
+  }
+  date {
+    match => [ "mail_date", "EEE, d MMM yyyy HH:mm:ss Z" ]
+    target => "@timestamp"
+    ignore_failure => true
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "imap-mail-%{+yyyy.MM.dd}"
+  }
+}

--- a/imap_elk_ingest/setup_ilm.sh
+++ b/imap_elk_ingest/setup_ilm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+curl -X PUT localhost:9200/_ilm/policy/imap_policy -H 'Content-Type: application/json' -d '{
+  "policy": {
+    "phases": {
+      "hot": {"actions": {"rollover": {"max_age": "30d", "max_size": "5gb"}}},
+      "delete": {"min_age": "180d", "actions": {"delete": {}}}
+    }
+  }
+}'
+
+curl -X PUT localhost:9200/_index_template/imap_mail_template -H 'Content-Type: application/json' -d '{
+  "index_patterns": ["imap-mail-*"],
+  "template": {
+    "settings": {
+      "index.lifecycle.name": "imap_policy",
+      "index.lifecycle.rollover_alias": "imap-mail"
+    }
+  }
+}'


### PR DESCRIPTION
## Summary
- implement new `imap_elk_ingest` folder with Docker Compose setup
- create custom Logstash Dockerfile and pipeline
- add ILM policy setup script
- document usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d2bdff27083229cf0cf1aed5f8cbd